### PR TITLE
Added install as dependency for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export TAG
 install:
 	go get .
 
-test:
+test: install
 	go test ./...
 
 build: install


### PR DESCRIPTION
On my MAC:
```
$ make ship
go test ./...
server.go:10:2: cannot find package "gopkg.in/yaml.v2" in any of:
	/usr/local/Cellar/go/1.9.2/libexec/src/gopkg.in/yaml.v2 (from $GOROOT)
	/Users/admin/Devel/golang/src/gopkg.in/yaml.v2 (from $GOPATH)
make: *** [test] Error 1
```